### PR TITLE
Remove `testFail` test pattern

### DIFF
--- a/packages/contracts/test/JwtRegistry/JwtRegistry_isDKIMPublicKeyHashValid.t.sol
+++ b/packages/contracts/test/JwtRegistry/JwtRegistry_isDKIMPublicKeyHashValid.t.sol
@@ -1,38 +1,50 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import 'forge-std/Test.sol';
-import 'forge-std/console.sol';
-import { JwtRegistryTestBase } from './JwtRegistryBase.t.sol';
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import {JwtRegistryTestBase} from "./JwtRegistryBase.t.sol";
 
 contract JwtRegistryTest_isDKIMPublicKeyHashValid is JwtRegistryTestBase {
-  constructor() {}
+    constructor() {}
 
-  function setUp() public override {
-    super.setUp();
-  }
+    function setUp() public override {
+        super.setUp();
+    }
 
-  function test_isDKIMPublicKeyHashValid_invalidKid() public view {
-    string memory domainName = '54321|https://example.com|client-id-12345';
-    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
-    assertFalse(res);
-  }
+    function test_isDKIMPublicKeyHashValid_invalidKid() public view {
+        string memory domainName = "54321|https://example.com|client-id-12345";
+        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
+            domainName,
+            publicKeyHash
+        );
+        assertFalse(res);
+    }
 
-  function test_isDKIMPublicKeyHashValid_invalidIss() public view {
-    string memory domainName = '12345|https://example.xyz|client-id-12345';
-    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
-    assertFalse(res);
-  }
+    function test_isDKIMPublicKeyHashValid_invalidIss() public view {
+        string memory domainName = "12345|https://example.xyz|client-id-12345";
+        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
+            domainName,
+            publicKeyHash
+        );
+        assertFalse(res);
+    }
 
-  function test_isDKIMPublicKeyHashValid_invalidAzp() public view {
-    string memory domainName = '12345|https://example.com|client-id-54321';
-    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
-    assertFalse(res);
-  }
+    function test_isDKIMPublicKeyHashValid_invalidAzp() public view {
+        string memory domainName = "12345|https://example.com|client-id-54321";
+        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
+            domainName,
+            publicKeyHash
+        );
+        assertFalse(res);
+    }
 
-  function test_isDKIMPublicKeyHashValid() public view {
-    string memory domainName = '12345|https://example.com|client-id-12345';
-    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
-    assertTrue(res);
-  }
+    function test_isDKIMPublicKeyHashValid() public view {
+        string memory domainName = "12345|https://example.com|client-id-12345";
+        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
+            domainName,
+            publicKeyHash
+        );
+        assertTrue(res);
+    }
 }

--- a/packages/contracts/test/JwtRegistry/JwtRegistry_isDKIMPublicKeyHashValid.t.sol
+++ b/packages/contracts/test/JwtRegistry/JwtRegistry_isDKIMPublicKeyHashValid.t.sol
@@ -1,50 +1,38 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.12;
 
-import "forge-std/Test.sol";
-import "forge-std/console.sol";
-import {JwtRegistryTestBase} from "./JwtRegistryBase.t.sol";
+import 'forge-std/Test.sol';
+import 'forge-std/console.sol';
+import { JwtRegistryTestBase } from './JwtRegistryBase.t.sol';
 
 contract JwtRegistryTest_isDKIMPublicKeyHashValid is JwtRegistryTestBase {
-    constructor() {}
+  constructor() {}
 
-    function setUp() public override {
-        super.setUp();
-    }
+  function setUp() public override {
+    super.setUp();
+  }
 
-    function testFail_isDKIMPublicKeyHashValid_invalidKid() public {
-        string memory domainName = "54321|https://example.com|client-id-12345";
-        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
-            domainName,
-            publicKeyHash
-        );
-        assertEq(res, true);
-    }
+  function test_isDKIMPublicKeyHashValid_invalidKid() public view {
+    string memory domainName = '54321|https://example.com|client-id-12345';
+    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
+    assertFalse(res);
+  }
 
-    function testFail_isDKIMPublicKeyHashValid_invalidIss() public {
-        string memory domainName = "12345|https://example.xyz|client-id-12345";
-        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
-            domainName,
-            publicKeyHash
-        );
-        assertEq(res, true);
-    }
+  function test_isDKIMPublicKeyHashValid_invalidIss() public view {
+    string memory domainName = '12345|https://example.xyz|client-id-12345';
+    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
+    assertFalse(res);
+  }
 
-    function testFail_isDKIMPublicKeyHashValid_invalidAzp() public {
-        string memory domainName = "12345|https://example.com|client-id-54321";
-        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
-            domainName,
-            publicKeyHash
-        );
-        assertEq(res, true);
-    }
+  function test_isDKIMPublicKeyHashValid_invalidAzp() public view {
+    string memory domainName = '12345|https://example.com|client-id-54321';
+    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
+    assertFalse(res);
+  }
 
-    function test_isDKIMPublicKeyHashValid() public {
-        string memory domainName = "12345|https://example.com|client-id-12345";
-        bool res = jwtRegistry.isDKIMPublicKeyHashValid(
-            domainName,
-            publicKeyHash
-        );
-        assertEq(res, true);
-    }
+  function test_isDKIMPublicKeyHashValid() public view {
+    string memory domainName = '12345|https://example.com|client-id-12345';
+    bool res = jwtRegistry.isDKIMPublicKeyHashValid(domainName, publicKeyHash);
+    assertTrue(res);
+  }
 }

--- a/packages/contracts/test/JwtRegistry/JwtRegistry_isJwtPublicKeyValid.t.sol
+++ b/packages/contracts/test/JwtRegistry/JwtRegistry_isJwtPublicKeyValid.t.sol
@@ -12,27 +12,27 @@ contract JwtRegistryTest_isJwtPublicKeyValid is JwtRegistryTestBase {
         super.setUp();
     }
 
-    function testFail_isJwtPublicKeyValid_invalidKid() public {
+    function test_isJwtPublicKeyValid_invalidKid() public view {
         string memory domainName = "54321|https://example.com|client-id-12345";
         bool res = jwtRegistry.isJwtPublicKeyValid(domainName, publicKeyHash);
-        assertEq(res, true);
+        assertFalse(res);
     }
 
-    function testFail_isJwtPublicKeyValid_invalidIss() public {
+    function test_isJwtPublicKeyValid_invalidIss() public view {
         string memory domainName = "12345|https://example.xyz|client-id-12345";
         bool res = jwtRegistry.isJwtPublicKeyValid(domainName, publicKeyHash);
-        assertEq(res, true);
+        assertFalse(res);
     }
 
-    function testFail_isJwtPublicKeyValid_invalidAzp() public {
+    function test_isJwtPublicKeyValid_invalidAzp() public view {
         string memory domainName = "12345|https://example.com|client-id-54321";
         bool res = jwtRegistry.isJwtPublicKeyValid(domainName, publicKeyHash);
-        assertEq(res, true);
+        assertFalse(res);
     }
 
-    function test_isJwtPublicKeyValid() public {
+    function test_isJwtPublicKeyValid() public view {
         string memory domainName = "12345|https://example.com|client-id-12345";
         bool res = jwtRegistry.isJwtPublicKeyValid(domainName, publicKeyHash);
-        assertEq(res, true);
+        assertTrue(res);
     }
 }


### PR DESCRIPTION
## Description

The `testFail*` pattern was deprecated [here](https://github.com/foundry-rs/foundry/pull/9574).

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have discussed with the team prior to submitting this PR
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
