### PR TITLE
Add view modifier to IVerifier.verifyEmailProof

### DIFF
--- a/packages/contracts/src/interfaces/IVerifier.sol
+++ b/packages/contracts/src/interfaces/IVerifier.sol
@@ -21,7 +21,7 @@ interface IVerifier {
      */    
     function verifyEmailProof(
         EmailProof memory proof
-    ) external returns (bool);
+    ) external view returns (bool);
 
     /**
      * @notice Returns a constant value representing command bytes.


### PR DESCRIPTION
## Description

The `view` modifier was removed at https://github.com/zkemail/zk-jwt/commit/20928d7f0f2c407076c30cb9e056cc2373361c1d. However, it seems that no implementation stops compiling if removed. I would understand that this is the intended behavior since [email-tx-builder also exposes such interface](https://github.com/zkemail/email-tx-builder/blob/main/packages/contracts/src/interfaces/IVerifier.sol)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
