### PR TITLE
Make stringToArray equivalent to previous implementation

### DIFF
--- a/packages/contracts/src/utils/StringToArrayUtils.sol
+++ b/packages/contracts/src/utils/StringToArrayUtils.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 import {Bytes} from "@openzeppelin/contracts/utils/Bytes.sol";
 
 library StringToArrayUtils {
+    bytes1 private constant PIPE = bytes1("|");
+    string private constant REVERT_REASON = "Invalid kid|iss|azp strings";
+
     /// @notice Converts a string containing three parts separated by '|' into an array of strings
     /// @param _strings The input string to be split
     /// @return An array of three strings, representing kid, iss, and azp
@@ -13,10 +16,18 @@ library StringToArrayUtils {
         bytes memory data = bytes(_strings);
         string[] memory parts = new string[](3);
         
-        uint256 start = 0;
-        for (uint256 i = 0; start < data.length; i++) {
-            uint256 end = i == 2 ? data.length : Bytes.indexOf(data, bytes1("|"), start);
-            require(i == 2 || end != type(uint256).max, "Invalid kid|iss|azp strings");
+        uint256 start; // 0
+        uint256 end; // 0
+        
+        for (uint256 i; i < 3; i++) {
+            if (i == 2) {
+                end = data.length;
+                require(start == Bytes.lastIndexOf(data, PIPE) + 1, REVERT_REASON);
+            } else {
+                end = Bytes.indexOf(data, PIPE, start);
+                require(end < data.length, REVERT_REASON);
+            }
+            
             parts[i] = string(Bytes.slice(data, start, end));
             start = end + 1;
         }

--- a/packages/contracts/test/JwtRegistry/JwtRegistry_disableAzp.t.sol
+++ b/packages/contracts/test/JwtRegistry/JwtRegistry_disableAzp.t.sol
@@ -17,7 +17,7 @@ contract JwtRegistryTest_disableAzp is JwtRegistryTestBase {
     function testRevert_disableAzp_invalidDomainNameFormat() public {
         vm.startPrank(deployer);
         string memory invalidDomainName = "12345|https://example.com";
-        vm.expectRevert(bytes("Invalid kid|iss|azp strings"));
+        vm.expectRevert("Invalid kid|iss|azp strings");
         jwtRegistry.disableAzp(invalidDomainName);
         vm.stopPrank();
     }
@@ -26,7 +26,7 @@ contract JwtRegistryTest_disableAzp is JwtRegistryTestBase {
         vm.startPrank(deployer);
         string
             memory invalidDomainName = "12345|https://example.com|client-id-12345|extra";
-        vm.expectRevert(bytes("Invalid kid|iss|azp strings"));
+        vm.expectRevert("Invalid kid|iss|azp strings");
         jwtRegistry.disableAzp(invalidDomainName);
         vm.stopPrank();
     }
@@ -34,7 +34,7 @@ contract JwtRegistryTest_disableAzp is JwtRegistryTestBase {
     function testRevert_disableAzp_emptyString() public {
         vm.startPrank(deployer);
         string memory invalidDomainName = "";
-        vm.expectRevert(bytes("Invalid kid|iss|azp strings"));
+        vm.expectRevert("Invalid kid|iss|azp strings");
         jwtRegistry.disableAzp(invalidDomainName);
         vm.stopPrank();
     }

--- a/packages/contracts/test/JwtRegistry/JwtRegistry_stringToArray.t.sol
+++ b/packages/contracts/test/JwtRegistry/JwtRegistry_stringToArray.t.sol
@@ -16,7 +16,7 @@ contract JwtRegistryTest_stringToArray is JwtRegistryTestBase {
         super.setUp();
     }
 
-    function test_stringToArray() public {
+    function test_stringToArray() public pure {
         string memory domainName = "12345|https://example.com|client-id-12345";
         string[] memory points = domainName.stringToArray();
         assertEq(points[0], "12345");


### PR DESCRIPTION
## Description

I realized that #13 tests were not passing for the `testRevert_disableAzp_tooManyParts` and `testRevert_disableAzp_emptyString`, so it seems that I was missing some semantical equivalence. This updates fix the implementation. Here's the gas diff

Original from #13 

```diff
-JwtRegistryTest_stringToArray:test_stringToArray() (gas: 28540)
+JwtRegistryTest_stringToArray:test_stringToArray() (gas: 10981)
```

From #13 to this PR

```diff
-JwtRegistryTest_stringToArray:test_stringToArray() (gas: 10981)
+JwtRegistryTest_stringToArray:test_stringToArray() (gas: 12617)
```

Overall

```diff
-JwtRegistryTest_stringToArray:test_stringToArray() (gas: 28540)
+JwtRegistryTest_stringToArray:test_stringToArray() (gas: 12617)
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have discussed with the team prior to submitting this PR
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
